### PR TITLE
Added deref unit test

### DIFF
--- a/src/belt.ts
+++ b/src/belt.ts
@@ -244,7 +244,7 @@ export function oderaf<
 	return ode(h_thing).reduce((a_out, [si_key, w_value], i_entry) => [
 		...a_out,
 		...f_concat(si_key, w_value, i_entry),
-	], []);
+	], [] as w_out[]);
 }
 
 

--- a/tests/unit/deref.test.ts
+++ b/tests/unit/deref.test.ts
@@ -1,0 +1,26 @@
+import { assertEquals } from "https://deno.land/std@0.205.0/assert/mod.ts";
+import { deref } from "../../src/json-schema.ts"
+
+Deno.test('deref should resolve $ref objects', () => {
+
+  const schema = {
+    $ref: "#/definitions/TestSchema",
+  };
+
+  const root = {
+    definitions: {
+      TestSchema: {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          date: { type: "date" },
+        },
+      }
+    }
+  };
+
+  const resolvedSchema = deref(schema, root);
+  const expectedSchema = root['definitions']['TestSchema'];
+
+  assertEquals(JSON.stringify(expectedSchema), JSON.stringify(resolvedSchema));
+});


### PR DESCRIPTION
## Update
Added initial unit test for the deref function. Checks if the ref object has been replaced with the definition. I wasn't able to run the code without having to typecase the output of oderaf, might be due to my environment. 