### PR TITLE
Add store test results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
               deno cache --reload --lock=deno.lock cli.ts 
               deno test --coverage=coverage
               deno coverage coverage --lcov --output=coverage/lcov.info
+              deno test --junit-path=./report.xml
       - persist_to_workspace:
             root: /home/circleci/
             paths:
@@ -30,7 +31,7 @@ jobs:
       - store_artifacts:
           path: /home/circleci/openapi-graph-extractor
       - store_test_results:
-          path: /home/circleci/openapi-graph-extractor/tests/unit
+          path: report
 workflows:
     version: 2
     test_and_scan:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - store_artifacts:
           path: /home/circleci/openapi-graph-extractor
       - store_test_results:
-          path: report
+          path: .
 workflows:
     version: 2
     test_and_scan:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,10 +27,11 @@ jobs:
             root: /home/circleci/
             paths:
               - openapi-graph-extractor
+              - openapi-graph-extractor/tests/test-result
       - store_artifacts:
           path: /home/circleci/openapi-graph-extractor
       - store_test_results:
-          path: /home/circleci/openapi-graph-extractor/test-results
+          path: /home/circleci/openapi-graph-extractor/tests/test-results
 workflows:
     version: 2
     test_and_scan:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,8 @@ jobs:
               - openapi-graph-extractor
       - store_artifacts:
           path: /home/circleci/openapi-graph-extractor
+      - store_test_results:
+          path: /home/circleci/openapi-graph-extractor/test-results
 workflows:
     version: 2
     test_and_scan:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,10 @@ jobs:
             root: /home/circleci/
             paths:
               - openapi-graph-extractor
-              - openapi-graph-extractor/tests/test-results
       - store_artifacts:
           path: /home/circleci/openapi-graph-extractor
       - store_test_results:
-          path: /home/circleci/openapi-graph-extractor/tests/test-results
+          path: /home/circleci/openapi-graph-extractor/tests/unit
 workflows:
     version: 2
     test_and_scan:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ jobs:
             root: /home/circleci/
             paths:
               - openapi-graph-extractor
-              - openapi-graph-extractor/tests/test-result
+              - openapi-graph-extractor/tests/test-results
       - store_artifacts:
           path: /home/circleci/openapi-graph-extractor
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,8 @@ jobs:
             name: Deno Test and Coverage Report
             command: |
               deno cache --reload --lock=deno.lock cli.ts 
-              deno test --coverage=coverage
+              deno test --coverage=coverage --junit-path=./report.xml
               deno coverage coverage --lcov --output=coverage/lcov.info
-              deno test --junit-path=./report.xml
       - persist_to_workspace:
             root: /home/circleci/
             paths:


### PR DESCRIPTION
Added store_test_results section following the run command in the steps in config.yaml file, in order to build and store test results. This section should allow test metadata to be listed under the test tab in CircleCI.

**Resources**

- https://circleci.com/docs/configuration-reference/#storetestresults
- https://circleci.com/docs/collect-test-data/

Fixes #9 